### PR TITLE
Fix some padding/spacing issues in speakers carousel

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -75,6 +75,12 @@ body, #qcSiteNav h4, #qcPriNav ul > li > a, #qcPriNav ul ul > li > a, .dash_titl
 /* END THEME CUSTOMIZATION */
 
 /* ---------- GLOBAL CLASSES ---------- */
+
+/* Clears focus color on touch devices*/
+body {
+	-webkit-tap-highlight-color: rgba(0,0,0,0);
+}
+
 /* HIDING ELEMENTS */
 .hidden {
 	display: none;
@@ -268,6 +274,12 @@ a:not(.button):hover {
 	#mobile-cta {
 		text-transform: none; /* Stops button breaking in half on tiny screens */
 	}
+}
+
+/* SPEAKERS SECTION STYLES */
+/* If speaker name is long keeps design consistent*/
+.speakers .item-title h3 {
+ 	min-height: 36px;
 }
 
 /* SPONSORS SECTION STYLES */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -920,17 +920,13 @@ video#qcBgVid {
 }
 .speakers .item-title {
 	position: relative;
-	padding: 50px 35px 100px 35px;
+	padding: 50px 35px 80px 35px;
 	background: #fff;
 	text-align: left;
 	z-index: 2;
-	transition: all .2s linear;
-    -o-transition: all .2s linear;
-    -moz-transition: all .2s linear;
-    -webkit-transition: all .2s linear;
 }
 .speakers .item .item-title {
-	padding-bottom: 150px;
+	padding-bottom: 100px;
 	margin-top: -50px;
 }
 .speakers .item-title h3, .speakers .item-desc h3 {
@@ -953,13 +949,9 @@ video#qcBgVid {
 	bottom: 0;
 	right: 0;
 	padding: 0 50px;
-	color: #666;
 	font: 400 16px/60px "Titillium Web", Helvetica, Arial, sans-serif;
 	text-transform: uppercase;
 	border-top: 1px #ccc solid;
-}
-.speakers .item .item-title .read-more {
-	color: red;
 }
 .speakers .item-desc {
 	display: none;
@@ -986,8 +978,6 @@ video#qcBgVid {
 	border: 0;
 }
 .spkr-social {
-	display: none;
-	position: absolute;
 	margin-top: 20px;
 }
 .speakers .item .spkr-social {
@@ -2310,9 +2300,9 @@ ul#slide-list li a:hover {
 	.speakers .item-title {
 		padding: 40px 35px 80px 35px;
 	}
-	.speakers .item:hover .item-title {
-		padding-bottom: 130px;
-		margin-top: -50px;
+	.speakers .item .item-title {
+		padding-bottom: 120px;
+		margin-top: -20px;
 	}
 	#qcTestimonial {
 		padding-left: 30px;
@@ -2457,8 +2447,8 @@ ul#slide-list li a:hover {
 		font-size: 14px;
 	}
 	.speakers .item .item-title {
-		padding-bottom: 130px;
-		margin-top: -50px;
+		padding-bottom: 80px;
+		margin-top: -20px;
 	}
 	.speakers .item-desc p.text {
 		font-size: 14px;

--- a/assets/js/init.js
+++ b/assets/js/init.js
@@ -89,7 +89,7 @@ if (jQuery.isFunction(jQuery.fn.owlCarousel)) {
 $(".qcSpeakerList").owlCarousel({
 	items : 3, //10 items above 1000px browser width
 	itemsDesktop : [1080,3], //5 items between 1000px and 901px
-	itemsDesktopSmall : [900,3], // betweem 900px and 601px
+	itemsDesktopSmall : [900,2], // betweem 900px and 601px
 	itemsTablet: [600,1], //2 items between 600 and 0
 	itemsMobile : [600,1], // itemsMobile disabled - inherit from itemsTablet option
 	navigation: true,

--- a/index.html
+++ b/index.html
@@ -129,7 +129,8 @@
 	<!-- coming soon! -->
 
 	<!-- ### SITE NAV END ### -->
-	<div class="hentry qcContainer speakers" id="speakers">
+<section class="speakers" id="speakers">
+	<div class="hentry qcContainer">
 		<h2 class="section-title margin-bottom">Our Speakers</h2>
 		<!-- ## SPEAKERS LIST ## -->
 		<ul class="qcSpeakerList">
@@ -194,6 +195,7 @@
 			</li>
 		</ul>
 	</div>
+</section>
 		<!-- ## SPEAKERS END ## -->
 
 


### PR DESCRIPTION
- Remove absolute positioning of social media icons
- Reduce padding
- Add min height for speakers name, in case name is long and wraps to
two lines it doesn’t displace the rest of the design