### PR TITLE
Add event markup for Rich Search Results

### DIFF
--- a/index.html
+++ b/index.html
@@ -528,6 +528,25 @@
 	  ga('send', 'pageview');
 
 	</script>
-
+	<script type="application/ld+json">
+		[{
+		  "@context": "http://schema.org",
+		  "@type" : "EventSeries",
+		  "name": "2017 WriteSpeakCode Conference",
+		  "url": "http://2017.writespeakcode.com",
+		  "startDate": "2017-08-23",
+		  "endDate": "2017-08-26",
+		  "description": "Conference for women in tech",
+		  "image": "http://2017.writespeakcode.com/assets/img/WSClogos_stacked_coral-blush-gold_screen.png",
+		  "location": {
+		    "@type": "EventVenue",
+		    "name": "Eliot Center",
+		    "address": "Portland, OR"
+		  },"offers": [{
+		    "@type": "Offer",
+		    "url": "https://ti.to/write-speak-code/2017-conference/"
+		  }]
+		}]
+	</script>
 </body>
 </html>


### PR DESCRIPTION
This data is used by Google to create "rich results" - if it works right we could have a little box with the event details in it at the top of the search results, like when you search for the weather or "movies near me" 

See [docs](https://developers.google.com/search/docs/data-types/events) for more info