### PR TITLE
Make speaker image 100% width on screens <400px wide

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -625,7 +625,7 @@ section.speakers .qcTabTitle .section-title {
   display: none;
 }
 .speaker-grid .gridder-list {
-  width: 50%;
+  width: 100%;
 }
 .speaker-grid .gridder-list:nth-child(n) {
   margin-bottom: 0;
@@ -634,6 +634,11 @@ section.speakers .qcTabTitle .section-title {
 .speaker-grid .gridder-list:nth-of-type(2n) {
   margin-right: 0;
   margin-bottom: 0;
+}
+@media screen and (min-width: 400px) {
+  .speaker-grid .gridder-list {
+    width: 50%;
+  }
 }
 @media screen and (min-width: 600px) {
   .speaker-grid .gridder-list {
@@ -1040,7 +1045,7 @@ input:focus, input:active {
   font-size: 15px;
   padding: 10px 0;
 }
-  
+
 .field__input:focus {
   border-bottom-color: #EB6851;
 }


### PR DESCRIPTION
- Solves name/title issue where long text covers photo & pushes + sign
off of the image

![speakers 1 across](https://cloud.githubusercontent.com/assets/11186572/26754022/c3a7f83e-4840-11e7-8458-a8a310662498.gif)
