### PR TITLE
Add width 100% to sponsor logo images

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -880,9 +880,11 @@ section.speakers .qcTabTitle .section-title {
 }
 .sponsors-section .sponsor-logo {
   max-width: 180px;
+  width: 100%;
 }
 .sponsors-section .supporter-logo {
   max-width: 150px;
+  width: 100%;
 }
 @media (max-width: 768px) {
   .sponsors-section .sponsor-logo,


### PR DESCRIPTION
- I believe this will fix the problem where the images break out of the container on safari iphone 6.
I think it's related to a max-width flexbox/safari bug.