### PR TITLE
Update countdown to reflect 9 am start time

### DIFF
--- a/assets/js/init.js
+++ b/assets/js/init.js
@@ -71,7 +71,7 @@ $('#qcCountdown').countDown({
 		'day': 		23,
 		'month': 	8,
 		'year': 	2017,
-		'hour': 	0,
+		'hour': 	9,
 		'min': 		0,
 		'sec': 		0
 	},


### PR DESCRIPTION
As far as I can tell, the countdown reflects the local users time :/ but spent a few mins trying to figure out if we could set the time zone, but I'm not sure we can with the current countdown library we are using. It's old I think because the website in the comments is not longer up.