### PR TITLE
Adds first group of accessibility edits

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -582,7 +582,7 @@ video#qcBgVid {
 	position: relative;
 	top: 25px;
 	padding: 0 8px 6px 0;
-	color: #aaa;
+	color: ##6d6d6d;
 	font: 300 16px/16px "Dosis", Helvetica, sans-serif;
 	text-transform: uppercase;
 	letter-spacing: 0.04em;

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <!-- ## SITE META ## -->
   <meta charset="utf-8">
@@ -58,7 +58,7 @@
           <p>Women in tech, let's take your career to the next level!<br class="hidden-on-xs"> Join us for 4 days designed to polish your skills and fully own your expertise through writing, speaking, and open source.</p>
         </div>
         <!-- ## COUNTDOWN TIMER ## -->
-        <div id="qcCountdown" class="clearfix">
+        <div id="qcCountdown" aria-hidden="true" class="clearfix">
           <!-- ## DAYS ## -->
           <div class="dash days_dash col-3 col">
             <div class="digits clearfix">
@@ -2452,15 +2452,15 @@
           <h3 class="col-xs-12 level-title">Silver Sponsors</h3>
           <div class="col-xs-12 col-sm-6 col-md-4">
               <a href="http://cdk-global.com" target="_blank" rel="noopener"><img class="sponsor-logo" src="assets/img/logos/cdk-logo.png" alt="Conference sponsor CDK Global logo"/></a>
-              <p><a href="http://cdk-global.com" target="_blank" rel="noopener">CDK Global</a> is the largest global provider of integrated information technology and digital marketing solutions to the automotive retail industry.</p>
+              <p>CDK Global is the largest global provider of integrated information technology and digital marketing solutions to the automotive retail industry.</p>
             </div>
             <div class="col-xs-12 col-sm-6 col-md-4">
               <a href="http://kcura.com" target="_blank" rel="noopener"><img class="sponsor-logo" src="assets/img/logos/kCura-logo.jpg" alt="Conference sponsor Kcura logo"/></a>
-              <p><a href="http://kcura.com" target="_blank" rel="noopener">kCura</a>: kCura develops e-discovery software Relativity for managing large volumes of electronic evidence during litigation or investigations.</p>
+              <p>kCura: kCura develops e-discovery software Relativity for managing large volumes of electronic evidence during litigation or investigations.</p>
             </div>
             <div class="col-xs-12 col-sm-6 col-md-4">
               <a href="https://mailchimp.com/" target="_blank" rel="noopener"><img class="sponsor-logo" src="assets/img/logos/mailchimp-logo.png" alt="Conference sponsor Mailchimp logo"/></a>
-              <p><a href="https://mailchimp.com/" target="_blank" rel="noopener">Mailchimp</a>: More than 10 million businesses around the world use MailChimp for marketing automation and email newsletters.</p>
+              <p>Mailchimp: More than 10 million businesses around the world use MailChimp for marketing automation and email newsletters.</p>
             </div>
 
         </div>
@@ -2469,7 +2469,7 @@
         <div class="row middle-md sponsor-level">
           <h3 class="col-xs-12 level-title">Bronze Sponsors</h3>
           <div class="col-xs">
-            <a href="http://xogroupinc.com/" target="_blank" rel="noopener"><img class="sponsor-logo" src="assets/img/logos/xogroup-logo.png" alt="Conference childcare sponsor Femgineer logo"/></a>
+            <a href="http://xogroupinc.com/" target="_blank" rel="noopener"><img class="sponsor-logo" src="assets/img/logos/xogroup-logo.png" alt="Conference childcare sponsor XO logo"/></a>
           </div>
           <div class="col-xs">
             <a href="https://puppet.com/" target="_blank" rel="noopener"><img class="sponsor-logo" src="assets/img/logos/puppet-logo.png" alt="Conference sponsor Puppet logo"/></a>
@@ -2802,9 +2802,9 @@
         <div class="col-xs-12 col-sm-8">
           <ul class="past-years">
             <h5>Past Years:</h5>
-            <li><a href="http://www.writespeakcode.com/2013" target="_blank" rel="noopener">2013</a></li>
-            <li><a href="http://2015.writespeakcode.com" target="_blank" rel="noopener">2015</a></li>
-            <li><a href="http://2016.writespeakcode.com" target="_blank" rel="noopener">2016</a></li>
+            <li><a href="http://www.writespeakcode.com/2013" target="_blank" rel="noopener" title="2013 W/S/C conference page">2013</a></li>
+            <li><a href="http://2015.writespeakcode.com" target="_blank" rel="noopener" title="2015 W/S/C conference page">2015</a></li>
+            <li><a href="http://2016.writespeakcode.com" target="_blank" rel="noopener" title="2016 W/S/C conference page">2016</a></li>
           </ul>
         </div>
         <div class="col-xs-12 col-sm-2 center-xs">


### PR DESCRIPTION
@jarmstrng Adds first group of accessibility improvements:

-Identifies document language as English
-Amends alt text for XO logo 
-Removes redundant links that are adjacent to each other (in sponsors section)
-Hides countdown on screen readers (testing if this works)
-Clarifies links in footer to previous year conferences
-Improves contrast of time in conference schedule (was a faint gray, now darker gray)
